### PR TITLE
gps: fall back to generic NMEA when vendor probes go unanswered

### DIFF
--- a/boards/gat562_mesh_tracker_pro.json
+++ b/boards/gat562_mesh_tracker_pro.json
@@ -1,0 +1,52 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "nrf52840_s140_v6.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_NRF52840_FEATHER -DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "hwids": [
+      ["0x239A", "0x8029"],
+      ["0x239A", "0x0029"],
+      ["0x239A", "0x002A"],
+      ["0x239A", "0x802A"]
+    ],
+    "usb_product": "GAT562 Mesh Tracker Pro",
+    "mcu": "nrf52840",
+    "variant": "gat562_mesh_tracker_pro",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "6.1.1",
+      "sd_fwid": "0x00B6"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": ["bluetooth"],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
+  },
+  "frameworks": ["arduino", "freertos"],
+  "name": "GAT562 Mesh Tracker Pro",
+  "upload": {
+    "maximum_ram_size": 248832,
+    "maximum_size": 815104,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": ["jlink", "nrfjprog", "nrfutil", "stlink"],
+    "use_1200bps_touch": true,
+    "require_upload_port": true,
+    "wait_for_upload_port": true
+  },
+  "url": "http://www.gat-iot.com/",
+  "vendor": "GAT"
+}

--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -75,6 +75,9 @@ static struct uBloxGnssModelInfo {
 #define GPS_SOL_EXPIRY_MS 5000 // in millis. give 1 second time to combine different sentences. NMEA Frequency isn't higher anyway
 #define NMEA_MSG_GXGSA "GNGSA" // GSA message (GPGSA, GNGSA etc)
 
+// How long to listen for a streaming NMEA GNSS before falling back to the generic NMEA driver
+#define GPS_NMEA_PROBE_TIMEOUT_MS 500
+
 namespace
 {
 // Versioned on-disk record for persisted GPS probe results.
@@ -1136,6 +1139,11 @@ bool GPS::setup()
             // enable RMC
             _serial_gps->write("$CFGMSG,0,4,1,1*1F\r\n");
             delay(250);
+        } else if (gnssModel == GNSS_MODEL_GENERIC_NMEA) {
+            // A module that auto-streams standard NMEA but ignores vendor probe commands (e.g. the GAT562's
+            // L76K in its default 9600 multi-GNSS mode). No chip-specific init is possible or needed: the
+            // streaming sentences are fed straight to the TinyGPS++ parser.
+            LOG_INFO("GNSS: using generic NMEA stream, skipping chip-specific init");
         }
         didSerialInit = true;
     }
@@ -1733,6 +1741,12 @@ GnssModel_t GPS::probe(int serialSpeed)
         // Check that the returned response class and message ID are correct
         GPS_RESPONSE response = getACK(0x06, 0x08, 750);
         if (response == GNSS_RESPONSE_NONE) {
+            if (sawNmeaSentenceAtBaud(_serial_gps, GPS_NMEA_PROBE_TIMEOUT_MS)) {
+                LOG_INFO("GNSS: no probe response, but NMEA stream detected at %d baud - using generic NMEA driver",
+                         serialSpeed);
+                currentStep = 0;
+                return GNSS_MODEL_GENERIC_NMEA;
+            }
             LOG_WARN("No GNSS Module (baudrate %d)", serialSpeed);
             currentDelay = 2000;
             currentStep = 0;
@@ -1820,6 +1834,11 @@ GnssModel_t GPS::probe(int serialSpeed)
             }
         }
     }
+    }
+    if (sawNmeaSentenceAtBaud(_serial_gps, GPS_NMEA_PROBE_TIMEOUT_MS)) {
+        LOG_INFO("GNSS: no probe response, but NMEA stream detected at %d baud - using generic NMEA driver", serialSpeed);
+        currentStep = 0;
+        return GNSS_MODEL_GENERIC_NMEA;
     }
     LOG_WARN("No GNSS Module (baudrate %d)", serialSpeed);
     currentDelay = 2000;

--- a/variants/nrf52840/gat562_mesh_tracker_pro/platformio.ini
+++ b/variants/nrf52840/gat562_mesh_tracker_pro/platformio.ini
@@ -1,0 +1,15 @@
+; GAT562 Mesh Tracker Pro with Trackball support
+[env:gat562_mesh_tracker_pro]
+extends = nrf52840_base
+board = gat562_mesh_tracker_pro
+board_level = extra
+build_flags = ${nrf52840_base.build_flags}
+  -I variants/nrf52840/gat562_mesh_tracker_pro
+  -D GAT562_MESH_TRACKER_PRO
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+  -DRADIOLIB_EXCLUDE_SX128X=1
+  -DRADIOLIB_EXCLUDE_SX127X=1
+  -DRADIOLIB_EXCLUDE_LR11X0=1
+build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/gat562_mesh_tracker_pro>
+lib_deps =
+  ${nrf52840_base.lib_deps}

--- a/variants/nrf52840/gat562_mesh_tracker_pro/variant.cpp
+++ b/variants/nrf52840/gat562_mesh_tracker_pro/variant.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    // P0
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+
+    // P1
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+void initVariant()
+{
+    // LED1 & LED2
+    pinMode(PIN_LED1, OUTPUT);
+    ledOff(PIN_LED1);
+
+    pinMode(PIN_LED2, OUTPUT);
+    ledOff(PIN_LED2);
+
+    // 3V3 Power Rail
+    pinMode(PIN_3V3_EN, OUTPUT);
+    digitalWrite(PIN_3V3_EN, HIGH);
+
+// Initialize trackball pins as inputs with pullup
+#ifdef HAS_TRACKBALL
+    pinMode(TB_UP, INPUT_PULLUP);
+    pinMode(TB_DOWN, INPUT_PULLUP);
+    pinMode(TB_LEFT, INPUT_PULLUP);
+    pinMode(TB_RIGHT, INPUT_PULLUP);
+    pinMode(TB_PRESS, INPUT_PULLUP);
+#endif
+}

--- a/variants/nrf52840/gat562_mesh_tracker_pro/variant.h
+++ b/variants/nrf52840/gat562_mesh_tracker_pro/variant.h
@@ -1,0 +1,300 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_GAT562_MESH_TRACKER_PRO_
+#define _VARIANT_GAT562_MESH_TRACKER_PRO_
+
+// led pin 2 (blue), see https://github.com/meshtastic/firmware/blob/master/src/mesh/NodeDB.cpp#L723
+#define RAK4630
+
+/** Master clock frequency */
+#define VARIANT_MCK (64000000ul)
+
+#define USE_LFXO // Board uses 32khz crystal for LF
+// define USE_LFRC    // Board uses RC for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT (48)
+#define NUM_DIGITAL_PINS (48)
+#define NUM_ANALOG_INPUTS (6)
+#define NUM_ANALOG_OUTPUTS (0)
+
+// LEDs
+#define PIN_LED1 (35)
+#define PIN_LED2 (36)
+
+#define LED_BUILTIN PIN_LED1
+#define LED_CONN PIN_LED2
+
+#define LED_GREEN PIN_LED1
+#define LED_BLUE PIN_LED2
+
+#define LED_STATE_ON 1 // State when LED is litted
+
+/*
+ * Buttons
+ */
+
+#define CANCEL_BUTTON_PIN 9
+#define BUTTON_NEED_PULLUP
+#define CANCEL_BUTTON_ACTIVE_LOW true
+#define CANCEL_BUTTON_ACTIVE_PULLUP false
+
+/*
+ * Analog pins
+ */
+#define PIN_A0 (5)
+#define PIN_A1 (31)
+#define PIN_A2 (28)
+#define PIN_A3 (29)
+#define PIN_A4 (30)
+#define PIN_A5 (31)
+#define PIN_A6 (0xff)
+#define PIN_A7 (0xff)
+
+static const uint8_t A0 = PIN_A0;
+static const uint8_t A1 = PIN_A1;
+static const uint8_t A2 = PIN_A2;
+static const uint8_t A3 = PIN_A3;
+static const uint8_t A4 = PIN_A4;
+static const uint8_t A5 = PIN_A5;
+static const uint8_t A6 = PIN_A6;
+static const uint8_t A7 = PIN_A7;
+#define ADC_RESOLUTION 14
+
+// Other pins
+#define PIN_AREF (2)
+#define PIN_NFC1 (9)
+#define PIN_NFC2 (10)
+
+static const uint8_t AREF = PIN_AREF;
+
+/*
+ * Serial interfaces
+ */
+#define PIN_SERIAL1_RX (15)
+#define PIN_SERIAL1_TX (16)
+
+// Connected to Jlink CDC
+#define PIN_SERIAL2_RX (8)
+#define PIN_SERIAL2_TX (6)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 2
+
+#define PIN_SPI_MISO (45)
+#define PIN_SPI_MOSI (44)
+#define PIN_SPI_SCK (43)
+
+#define PIN_SPI1_MISO (29) // (0 + 29)
+#define PIN_SPI1_MOSI (30) // (0 + 30)
+#define PIN_SPI1_SCK (3)   // (0 + 3)
+
+static const uint8_t SS = 42;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK = PIN_SPI_SCK;
+
+/*
+ * eink display pins
+ */
+
+// #define PIN_EINK_CS (0 + 26)
+// #define PIN_EINK_BUSY (0 + 4)
+// #define PIN_EINK_DC (0 + 17)
+// #define PIN_EINK_RES (-1)
+// #define PIN_EINK_SCLK (0 + 3)
+// #define PIN_EINK_MOSI (0 + 30) // also called SDI
+
+// #define USE_EINK
+
+// Display - OLED connected via I2C
+#define HAS_SCREEN 1
+#define USE_SSD1306
+
+// RAKRGB
+// #define HAS_NCP5623
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA (13)
+#define PIN_WIRE_SCL (14)
+
+// QSPI Pins
+#define PIN_QSPI_SCK 3
+#define PIN_QSPI_CS 26
+#define PIN_QSPI_IO0 30
+#define PIN_QSPI_IO1 29
+#define PIN_QSPI_IO2 28
+#define PIN_QSPI_IO3 2
+
+// On-board QSPI Flash
+#define EXTERNAL_FLASH_DEVICES IS25LP080D
+#define EXTERNAL_FLASH_USE_QSPI
+
+/* @note RAK5005-O GPIO mapping to RAK4631 GPIO ports
+   RAK5005-O <->  nRF52840
+   IO1       <->  P0.17 (Arduino GPIO number 17)
+   IO2       <->  P1.02 (Arduino GPIO number 34)
+   IO3       <->  P0.21 (Arduino GPIO number 21)
+   IO4       <->  P0.04 (Arduino GPIO number 4)
+   IO5       <->  P0.09 (Arduino GPIO number 9)
+   IO6       <->  P0.10 (Arduino GPIO number 10)
+   IO7       <->  P0.28 (Arduino GPIO number 28)
+   SW1       <->  P0.01 (Arduino GPIO number 1)
+   A0        <->  P0.04/AIN2 (Arduino Analog A2
+   A1        <->  P0.31/AIN7 (Arduino Analog A7
+   SPI_CS    <->  P0.26 (Arduino GPIO number 26)
+ */
+
+// RAK4630 LoRa module
+
+/* Setup of the SX1262 LoRa module ( https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Datasheet/ )
+
+P1.10   NSS     SPI NSS (Arduino GPIO number 42)
+P1.11   SCK     SPI CLK (Arduino GPIO number 43)
+P1.12   MOSI    SPI MOSI (Arduino GPIO number 44)
+P1.13   MISO    SPI MISO (Arduino GPIO number 45)
+P1.14   BUSY    BUSY signal (Arduino GPIO number 46)
+P1.15   DIO1    DIO1 event interrupt (Arduino GPIO number 47)
+P1.06   NRESET  NRESET manual reset of the SX1262 (Arduino GPIO number 38)
+
+Important for successful SX1262 initialization:
+
+* Setup DIO2 to control the antenna switch
+* Setup DIO3 to control the TCXO power supply
+* Setup the SX1262 to use it's DCDC regulator and not the LDO
+* RAK4630 schematics show GPIO P1.07 connected to the antenna switch, but it should not be initialized, as DIO2 will do the
+control of the antenna switch
+
+SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
+
+*/
+
+// configure the SET pin on the RAK12039 sensor board to disable the sensor while not reading
+// air quality telemetry.  PIN_NFC2 doesn't seem to be used anywhere else in the codebase, but if
+// you're having problems with your node behaving weirdly when a RAK12039 board isn't connected,
+// try disabling this.
+// #define PMSA003I_ENABLE_PIN PIN_NFC2
+
+// #define DETECTION_SENSOR_EN 4
+
+#define USE_SX1262
+#define SX126X_CS (42)
+#define SX126X_DIO1 (47)
+#define SX126X_BUSY (46)
+#define SX126X_RESET (38)
+// #define SX126X_TXEN (39)
+// #define SX126X_RXEN (37)
+#define SX126X_POWER_EN (37)
+// DIO2 controlls an antenna switch and the TCXO voltage is controlled by DIO3
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+// Testing USB detection
+#define NRF_APM
+
+// enables 3.3V periphery like GPS or IO Module
+// Do not toggle this for GPS power savings
+#define PIN_3V3_EN (34)
+
+// RAK1910 GPS module
+// If using the wisblock GPS module and pluged into Port A on WisBlock base
+// IO1 is hooked to PPS (pin 12 on header) = gpio 17
+// IO2 is hooked to GPS RESET = gpio 34, but it can not be used to this because IO2 is ALSO used to control 3V3_S power (1 is on).
+// Therefore must be 1 to keep peripherals powered
+// Power is on the controllable 3V3_S rail
+// #define PIN_GPS_RESET (34)
+// #define PIN_GPS_EN PIN_3V3_EN
+#define PIN_GPS_PPS (17) // Pulse per second input from the GPS
+
+#define GPS_BAUDRATE 9600
+
+#define GPS_RX_PIN PIN_SERIAL1_RX
+#define GPS_TX_PIN PIN_SERIAL1_TX
+
+// Define pin to enable GPS toggle (set GPIO to LOW) via user button triple press
+
+// RAK12002 RTC Module
+// #define RV3028_RTC (uint8_t)0b1010010
+
+// RAK18001 Buzzer in Slot C
+// #define PIN_BUZZER 21 // IO3 is PWM2
+// NEW: set this via protobuf instead!
+
+// Battery
+// The battery sense is hooked to pin A0 (5)
+#define BATTERY_PIN PIN_A0
+// and has 12 bit resolution
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+#define BATTERY_SENSE_RESOLUTION 4096.0
+#undef AREF_VOLTAGE
+#define AREF_VOLTAGE 3.0
+#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
+#define ADC_MULTIPLIER 1.73
+
+// #define HAS_RTC 1
+
+// #define HAS_ETHERNET 1
+
+// #define RAK_4631 1
+
+// #define PIN_ETHERNET_RESET 21
+// #define PIN_ETHERNET_SS PIN_EINK_CS
+// #define ETH_SPI_PORT SPI1
+// #define AQ_SET_PIN 10
+
+// ????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
+//  Trackball Configuration
+// ????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
+#define CANNED_MESSAGE_MODULE_ENABLE 1
+#define CANNED_MESSAGE_ADD_CONFIRMATION 1
+
+// Trackball pins
+#define HAS_TRACKBALL 1
+#define TB_LEFT 30  // P0.30
+#define TB_DOWN 4   // P0.04
+#define TB_RIGHT 31 // P0.31
+#define TB_UP 28    // P0.28
+#define TB_PRESS 26 // P0.26 (SELECT)
+#define TB_DIRECTION FALLING
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
## Summary

GPS fix: when the GNSS probe fails to get a vendor-specific response but a valid NMEA stream is arriving on the GPS UART, select a new generic-NMEA driver instead of concluding "no GPS".

## Problem

Some GNSS modules auto-stream standard NMEA but never answer chip-specific probe commands. The GAT562 Mesh Tracker Pro's L76K (CASIC-family) module is one such case: it runs in its default 9600 baud multi-GNSS (GPS + BeiDou) mode and streams `$GNGGA` / `$GNRMC` / `$GPGSV`, but it does not reply to any of the vendor probes Meshtastic sends (`$PUBX`, `$PMTK605`, `$PCAS06`, `$PQTMVERNO`, `$PDTINFO`, `$PAIR021`, UBX config, ...).

`GPS::probe()` / `GPS::setup()` interpret the silence as "no GNSS present", so the module's NMEA is never fed to the TinyGPS++ parser and no positions ever reach the mesh.

## Fix

- Add `GNSS_MODEL_GENERIC_NMEA`.
- In `GPS::probe()`, at the end of each baud-rate attempt where no chip responded to any probe command, listen for a short window (500 ms) for known NMEA sentence types (`GGA`, `RMC`, `GSV`, `GSA`, `VTG`, `GLL`, `ZDA`). If a stream is detected, return `GNSS_MODEL_GENERIC_NMEA` for that baud rate instead of `GNSS_MODEL_UNKNOWN`.
- `GPS::setup()` sends no chip-specific init for the generic driver (u-blox / MTK / L76K / Airoha / ATGM / Unicore configuration is all skipped) and feeds the streaming sentences straight to the standard TinyGPS++ parser.

The check only fires when a known NMEA stream is actually present, so true "no GPS" devices are unaffected (they still fall through to the existing `No GNSS Module` path).

## Verification

Device serial log (`gat562_mesh_tracker_pro`, `2.7.23.b2bda3b`):

```
[GPS] Trying $PDTINFO (Unicore Family)...
[GPS] Trying $PCAS06,1*1A (ATGM33xx Family)...
[GPS] Trying $PAIR021*39 (Airoha Family)...
[GPS] Trying $PQTMVERNO*58 (LC86)...
[GPS] Trying $PCAS06,0*1B (L76K)...
[GPS] Trying $PMTK605*31 (MTK Family)...
[GPS] GNSS: no probe response, but NMEA stream detected at 9600 baud - using generic NMEA driver
[GPS] GNSS: using generic NMEA stream, skipping chip-specific init
[GPS] NMEA GPS time set ...
```

The NMEA stream is parsed (time source acquired from GPS); a position fix then depends on normal cold-start satellite acquisition.

## Should be pushed upstream to Meshtastic

This fix belongs in upstream Meshtastic, not just the GAT562 fork. It likely benefits other hardware:

- Any GNSS module that streams NMEA but ignores vendor probe commands.
- Boards with one-way UART wiring (MCU RX to GNSS TX only), where probe commands can never reach the module but NMEA still arrives.
- Modules running in generic NMEA mode where a vendor driver was never selected.

The fallback is conservative (only activates on a confirmed NMEA stream) and requires no config or wiring changes.

## Question for the board manufacturer (GAT / gat-iot.com)

On the GAT562 Mesh Tracker Pro, is the MCU's GPS TX (GPIO16 / P0.16) actually wired to the L76K module's UART RX input?

The probe phase transmits `$PCAS06` and every other vendor probe command, and none get a reply while NMEA continues to stream in. That is exactly the behavior expected if the MCU-to-L76K TX path is omitted on the PCB (one-way UART: the L76K talks, but the MCU cannot send to it). If the TX line is absent, this generic-NMEA fallback is required (and is the only way) to obtain positions from this board.
